### PR TITLE
Upgrade app to Rails 4.1.0.beta1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ notifications:
 before_script:
 - export DISPLAY=:99.0
 - sh -e /etc/init.d/xvfb start
+before_install: gem update bundler
 env:
   global:
     secure: ZB3cJsUoaPMAp9dTycSQFtP47sMOD6bmOt7uaY9WLZ0bbg7BrjkD1pShYDa6ZyUo8FzGkvnAEjUojFT8LICdgT7uFMREIU+c46MnOb6m9/6AHM/m0vJzNfYO1eW8wOGr8Lzp6Cn+kYsrHCC2Bar503c1FfRDihKP1SUubJwSC68=

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,10 @@ notifications:
     - gmacie@hotmail.com
     on_success: change
     on_failure: always
+before_install: gem update bundler
 before_script:
 - export DISPLAY=:99.0
 - sh -e /etc/init.d/xvfb start
-before_install: gem update bundler
 env:
   global:
     secure: ZB3cJsUoaPMAp9dTycSQFtP47sMOD6bmOt7uaY9WLZ0bbg7BrjkD1pShYDa6ZyUo8FzGkvnAEjUojFT8LICdgT7uFMREIU+c46MnOb6m9/6AHM/m0vJzNfYO1eW8wOGr8Lzp6Cn+kYsrHCC2Bar503c1FfRDihKP1SUubJwSC68=

--- a/Gemfile
+++ b/Gemfile
@@ -53,7 +53,7 @@ end
 group :test do
   gem 'capybara'
   gem 'cucumber-rails', require: false
-  gem 'database_cleaner', '1.0.1'
+  gem 'database_cleaner'
   gem 'email_spec'
   gem 'launchy'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 ruby '2.1.0'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
-gem 'rails', '4.1.0.beta1'
+gem 'rails', '4.0.2'
 
 # Use jquery as the JavaScript library.
 gem 'jquery-rails'
@@ -27,7 +27,7 @@ gem 'uglifier'
 
 gem 'geocoder'
 
-gem 'figaro', :git => 'git://github.com/laserlemon/figaro.git'
+gem 'figaro'
 
 gem 'rabl'
 

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 ruby '2.1.0'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
-gem 'rails', '4.0.2'
+gem 'rails', '4.1.0.beta1'
 
 # Use jquery as the JavaScript library.
 gem 'jquery-rails'
@@ -27,7 +27,7 @@ gem 'uglifier'
 
 gem 'geocoder'
 
-gem 'figaro'
+gem 'figaro', :git => 'git://github.com/laserlemon/figaro.git'
 
 gem 'rabl'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,42 +1,32 @@
-GIT
-  remote: git://github.com/laserlemon/figaro.git
-  revision: 6533e165019b191dd2903f979a80f78931d82ad8
-  specs:
-    figaro (0.7.0)
-      bundler (~> 1.0)
-      rails (>= 3, < 5)
-
 GEM
   remote: https://rubygems.org/
   specs:
-    actionmailer (4.1.0.beta1)
-      actionpack (= 4.1.0.beta1)
-      actionview (= 4.1.0.beta1)
+    actionmailer (4.0.2)
+      actionpack (= 4.0.2)
       mail (~> 2.5.4)
-    actionpack (4.1.0.beta1)
-      actionview (= 4.1.0.beta1)
-      activesupport (= 4.1.0.beta1)
+    actionpack (4.0.2)
+      activesupport (= 4.0.2)
+      builder (~> 3.1.0)
+      erubis (~> 2.7.0)
       rack (~> 1.5.2)
       rack-test (~> 0.6.2)
-    actionview (4.1.0.beta1)
-      activesupport (= 4.1.0.beta1)
-      builder (~> 3.1)
-      erubis (~> 2.7.0)
-    activemodel (4.1.0.beta1)
-      activesupport (= 4.1.0.beta1)
-      builder (~> 3.1)
-    activerecord (4.1.0.beta1)
-      activemodel (= 4.1.0.beta1)
-      activesupport (= 4.1.0.beta1)
-      arel (~> 5.0.0)
-    activesupport (4.1.0.beta1)
-      i18n (~> 0.6, >= 0.6.9)
-      json (~> 1.7, >= 1.7.7)
-      minitest (~> 5.1)
+    activemodel (4.0.2)
+      activesupport (= 4.0.2)
+      builder (~> 3.1.0)
+    activerecord (4.0.2)
+      activemodel (= 4.0.2)
+      activerecord-deprecated_finders (~> 1.0.2)
+      activesupport (= 4.0.2)
+      arel (~> 4.0.0)
+    activerecord-deprecated_finders (1.0.3)
+    activesupport (4.0.2)
+      i18n (~> 0.6, >= 0.6.4)
+      minitest (~> 4.2)
+      multi_json (~> 1.3)
       thread_safe (~> 0.1)
-      tzinfo (~> 1.1)
+      tzinfo (~> 0.3.37)
     addressable (2.3.5)
-    arel (5.0.0)
+    arel (4.0.1)
     atomic (1.1.14)
     awesome_print (1.2.0)
     bcrypt-ruby (3.1.2)
@@ -45,7 +35,7 @@ GEM
       erubis (>= 2.6.6)
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
-    builder (3.2.2)
+    builder (3.1.4)
     capybara (2.2.0)
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
@@ -97,6 +87,9 @@ GEM
     factory_girl_rails (4.3.0)
       factory_girl (~> 4.3.0)
       railties (>= 3.0.0)
+    figaro (0.7.0)
+      bundler (~> 1.0)
+      rails (>= 3, < 5)
     geocoder (1.1.9)
     gherkin (2.12.2)
       multi_json (~> 1.3)
@@ -119,7 +112,7 @@ GEM
     method_source (0.8.2)
     mime-types (1.25.1)
     mini_portile (0.5.2)
-    minitest (5.2.0)
+    minitest (4.7.5)
     multi_json (1.8.2)
     multi_test (0.0.2)
     nokogiri (1.6.1)
@@ -138,24 +131,22 @@ GEM
     rack (1.5.2)
     rack-test (0.6.2)
       rack (>= 1.0)
-    rails (4.1.0.beta1)
-      actionmailer (= 4.1.0.beta1)
-      actionpack (= 4.1.0.beta1)
-      actionview (= 4.1.0.beta1)
-      activemodel (= 4.1.0.beta1)
-      activerecord (= 4.1.0.beta1)
-      activesupport (= 4.1.0.beta1)
+    rails (4.0.2)
+      actionmailer (= 4.0.2)
+      actionpack (= 4.0.2)
+      activerecord (= 4.0.2)
+      activesupport (= 4.0.2)
       bundler (>= 1.3.0, < 2.0)
-      railties (= 4.1.0.beta1)
+      railties (= 4.0.2)
       sprockets-rails (~> 2.0.0)
     rails_12factor (0.0.2)
       rails_serve_static_assets
       rails_stdout_logging
     rails_serve_static_assets (0.0.2)
     rails_stdout_logging (0.0.3)
-    railties (4.1.0.beta1)
-      actionpack (= 4.1.0.beta1)
-      activesupport (= 4.1.0.beta1)
+    railties (4.0.2)
+      actionpack (= 4.0.2)
+      activesupport (= 4.0.2)
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rake (10.1.1)
@@ -213,8 +204,7 @@ GEM
     treetop (1.4.15)
       polyglot
       polyglot (>= 0.3.1)
-    tzinfo (1.1.0)
-      thread_safe (~> 0.1)
+    tzinfo (0.3.38)
     uglifier (2.4.0)
       execjs (>= 0.3.0)
       json (>= 1.8.0)
@@ -238,7 +228,7 @@ DEPENDENCIES
   devise
   email_spec
   factory_girl_rails
-  figaro!
+  figaro
   geocoder
   jbuilder
   jquery-rails
@@ -248,7 +238,7 @@ DEPENDENCIES
   pry
   quiet_assets
   rabl
-  rails (= 4.1.0.beta1)
+  rails (= 4.0.2)
   rails_12factor
   rspec-rails
   sass-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -67,7 +67,7 @@ GEM
       cucumber (>= 1.2.0)
       nokogiri (>= 1.5.0)
       rails (>= 3.0.0)
-    database_cleaner (1.0.1)
+    database_cleaner (1.2.0)
     debug_inspector (0.0.2)
     devise (3.2.2)
       bcrypt-ruby (~> 3.0)
@@ -224,7 +224,7 @@ DEPENDENCIES
   coffee-rails
   coveralls
   cucumber-rails
-  database_cleaner (= 1.0.1)
+  database_cleaner
   devise
   email_spec
   factory_girl_rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,32 +1,42 @@
+GIT
+  remote: git://github.com/laserlemon/figaro.git
+  revision: 6533e165019b191dd2903f979a80f78931d82ad8
+  specs:
+    figaro (0.7.0)
+      bundler (~> 1.0)
+      rails (>= 3, < 5)
+
 GEM
   remote: https://rubygems.org/
   specs:
-    actionmailer (4.0.2)
-      actionpack (= 4.0.2)
+    actionmailer (4.1.0.beta1)
+      actionpack (= 4.1.0.beta1)
+      actionview (= 4.1.0.beta1)
       mail (~> 2.5.4)
-    actionpack (4.0.2)
-      activesupport (= 4.0.2)
-      builder (~> 3.1.0)
-      erubis (~> 2.7.0)
+    actionpack (4.1.0.beta1)
+      actionview (= 4.1.0.beta1)
+      activesupport (= 4.1.0.beta1)
       rack (~> 1.5.2)
       rack-test (~> 0.6.2)
-    activemodel (4.0.2)
-      activesupport (= 4.0.2)
-      builder (~> 3.1.0)
-    activerecord (4.0.2)
-      activemodel (= 4.0.2)
-      activerecord-deprecated_finders (~> 1.0.2)
-      activesupport (= 4.0.2)
-      arel (~> 4.0.0)
-    activerecord-deprecated_finders (1.0.3)
-    activesupport (4.0.2)
-      i18n (~> 0.6, >= 0.6.4)
-      minitest (~> 4.2)
-      multi_json (~> 1.3)
+    actionview (4.1.0.beta1)
+      activesupport (= 4.1.0.beta1)
+      builder (~> 3.1)
+      erubis (~> 2.7.0)
+    activemodel (4.1.0.beta1)
+      activesupport (= 4.1.0.beta1)
+      builder (~> 3.1)
+    activerecord (4.1.0.beta1)
+      activemodel (= 4.1.0.beta1)
+      activesupport (= 4.1.0.beta1)
+      arel (~> 5.0.0)
+    activesupport (4.1.0.beta1)
+      i18n (~> 0.6, >= 0.6.9)
+      json (~> 1.7, >= 1.7.7)
+      minitest (~> 5.1)
       thread_safe (~> 0.1)
-      tzinfo (~> 0.3.37)
+      tzinfo (~> 1.1)
     addressable (2.3.5)
-    arel (4.0.1)
+    arel (5.0.0)
     atomic (1.1.14)
     awesome_print (1.2.0)
     bcrypt-ruby (3.1.2)
@@ -35,7 +45,7 @@ GEM
       erubis (>= 2.6.6)
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
-    builder (3.1.4)
+    builder (3.2.2)
     capybara (2.2.0)
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
@@ -87,9 +97,6 @@ GEM
     factory_girl_rails (4.3.0)
       factory_girl (~> 4.3.0)
       railties (>= 3.0.0)
-    figaro (0.7.0)
-      bundler (~> 1.0)
-      rails (>= 3, < 5)
     geocoder (1.1.9)
     gherkin (2.12.2)
       multi_json (~> 1.3)
@@ -112,9 +119,9 @@ GEM
     method_source (0.8.2)
     mime-types (1.25.1)
     mini_portile (0.5.2)
-    minitest (4.7.5)
+    minitest (5.2.0)
     multi_json (1.8.2)
-    multi_test (0.0.2)
+    multi_test (0.0.3)
     nokogiri (1.6.1)
       mini_portile (~> 0.5.0)
     orm_adapter (0.5.0)
@@ -131,22 +138,24 @@ GEM
     rack (1.5.2)
     rack-test (0.6.2)
       rack (>= 1.0)
-    rails (4.0.2)
-      actionmailer (= 4.0.2)
-      actionpack (= 4.0.2)
-      activerecord (= 4.0.2)
-      activesupport (= 4.0.2)
+    rails (4.1.0.beta1)
+      actionmailer (= 4.1.0.beta1)
+      actionpack (= 4.1.0.beta1)
+      actionview (= 4.1.0.beta1)
+      activemodel (= 4.1.0.beta1)
+      activerecord (= 4.1.0.beta1)
+      activesupport (= 4.1.0.beta1)
       bundler (>= 1.3.0, < 2.0)
-      railties (= 4.0.2)
+      railties (= 4.1.0.beta1)
       sprockets-rails (~> 2.0.0)
     rails_12factor (0.0.2)
       rails_serve_static_assets
       rails_stdout_logging
     rails_serve_static_assets (0.0.2)
     rails_stdout_logging (0.0.3)
-    railties (4.0.2)
-      actionpack (= 4.0.2)
-      activesupport (= 4.0.2)
+    railties (4.1.0.beta1)
+      actionpack (= 4.1.0.beta1)
+      activesupport (= 4.1.0.beta1)
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rake (10.1.1)
@@ -204,7 +213,8 @@ GEM
     treetop (1.4.15)
       polyglot
       polyglot (>= 0.3.1)
-    tzinfo (0.3.38)
+    tzinfo (1.1.0)
+      thread_safe (~> 0.1)
     uglifier (2.4.0)
       execjs (>= 0.3.0)
       json (>= 1.8.0)
@@ -228,7 +238,7 @@ DEPENDENCIES
   devise
   email_spec
   factory_girl_rails
-  figaro
+  figaro!
   geocoder
   jbuilder
   jquery-rails
@@ -238,7 +248,7 @@ DEPENDENCIES
   pry
   quiet_assets
   rabl
-  rails (= 4.0.2)
+  rails (= 4.1.0.beta1)
   rails_12factor
   rspec-rails
   sass-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,32 +1,42 @@
+GIT
+  remote: git://github.com/laserlemon/figaro.git
+  revision: 6533e165019b191dd2903f979a80f78931d82ad8
+  specs:
+    figaro (0.7.0)
+      bundler (~> 1.0)
+      rails (>= 3, < 5)
+
 GEM
   remote: https://rubygems.org/
   specs:
-    actionmailer (4.0.2)
-      actionpack (= 4.0.2)
+    actionmailer (4.1.0.beta1)
+      actionpack (= 4.1.0.beta1)
+      actionview (= 4.1.0.beta1)
       mail (~> 2.5.4)
-    actionpack (4.0.2)
-      activesupport (= 4.0.2)
-      builder (~> 3.1.0)
-      erubis (~> 2.7.0)
+    actionpack (4.1.0.beta1)
+      actionview (= 4.1.0.beta1)
+      activesupport (= 4.1.0.beta1)
       rack (~> 1.5.2)
       rack-test (~> 0.6.2)
-    activemodel (4.0.2)
-      activesupport (= 4.0.2)
-      builder (~> 3.1.0)
-    activerecord (4.0.2)
-      activemodel (= 4.0.2)
-      activerecord-deprecated_finders (~> 1.0.2)
-      activesupport (= 4.0.2)
-      arel (~> 4.0.0)
-    activerecord-deprecated_finders (1.0.3)
-    activesupport (4.0.2)
-      i18n (~> 0.6, >= 0.6.4)
-      minitest (~> 4.2)
-      multi_json (~> 1.3)
+    actionview (4.1.0.beta1)
+      activesupport (= 4.1.0.beta1)
+      builder (~> 3.1)
+      erubis (~> 2.7.0)
+    activemodel (4.1.0.beta1)
+      activesupport (= 4.1.0.beta1)
+      builder (~> 3.1)
+    activerecord (4.1.0.beta1)
+      activemodel (= 4.1.0.beta1)
+      activesupport (= 4.1.0.beta1)
+      arel (~> 5.0.0)
+    activesupport (4.1.0.beta1)
+      i18n (~> 0.6, >= 0.6.9)
+      json (~> 1.7, >= 1.7.7)
+      minitest (~> 5.1)
       thread_safe (~> 0.1)
-      tzinfo (~> 0.3.37)
+      tzinfo (~> 1.1)
     addressable (2.3.5)
-    arel (4.0.1)
+    arel (5.0.0)
     atomic (1.1.14)
     awesome_print (1.2.0)
     bcrypt-ruby (3.1.2)
@@ -35,7 +45,7 @@ GEM
       erubis (>= 2.6.6)
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
-    builder (3.1.4)
+    builder (3.2.2)
     capybara (2.2.0)
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
@@ -87,9 +97,6 @@ GEM
     factory_girl_rails (4.3.0)
       factory_girl (~> 4.3.0)
       railties (>= 3.0.0)
-    figaro (0.7.0)
-      bundler (~> 1.0)
-      rails (>= 3, < 5)
     geocoder (1.1.9)
     gherkin (2.12.2)
       multi_json (~> 1.3)
@@ -112,7 +119,7 @@ GEM
     method_source (0.8.2)
     mime-types (1.25.1)
     mini_portile (0.5.2)
-    minitest (4.7.5)
+    minitest (5.2.0)
     multi_json (1.8.2)
     multi_test (0.0.2)
     nokogiri (1.6.1)
@@ -131,22 +138,24 @@ GEM
     rack (1.5.2)
     rack-test (0.6.2)
       rack (>= 1.0)
-    rails (4.0.2)
-      actionmailer (= 4.0.2)
-      actionpack (= 4.0.2)
-      activerecord (= 4.0.2)
-      activesupport (= 4.0.2)
+    rails (4.1.0.beta1)
+      actionmailer (= 4.1.0.beta1)
+      actionpack (= 4.1.0.beta1)
+      actionview (= 4.1.0.beta1)
+      activemodel (= 4.1.0.beta1)
+      activerecord (= 4.1.0.beta1)
+      activesupport (= 4.1.0.beta1)
       bundler (>= 1.3.0, < 2.0)
-      railties (= 4.0.2)
+      railties (= 4.1.0.beta1)
       sprockets-rails (~> 2.0.0)
     rails_12factor (0.0.2)
       rails_serve_static_assets
       rails_stdout_logging
     rails_serve_static_assets (0.0.2)
     rails_stdout_logging (0.0.3)
-    railties (4.0.2)
-      actionpack (= 4.0.2)
-      activesupport (= 4.0.2)
+    railties (4.1.0.beta1)
+      actionpack (= 4.1.0.beta1)
+      activesupport (= 4.1.0.beta1)
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rake (10.1.1)
@@ -204,7 +213,8 @@ GEM
     treetop (1.4.15)
       polyglot
       polyglot (>= 0.3.1)
-    tzinfo (0.3.38)
+    tzinfo (1.1.0)
+      thread_safe (~> 0.1)
     uglifier (2.4.0)
       execjs (>= 0.3.0)
       json (>= 1.8.0)
@@ -228,7 +238,7 @@ DEPENDENCIES
   devise
   email_spec
   factory_girl_rails
-  figaro
+  figaro!
   geocoder
   jbuilder
   jquery-rails
@@ -238,7 +248,7 @@ DEPENDENCIES
   pry
   quiet_assets
   rabl
-  rails (= 4.0.2)
+  rails (= 4.1.0.beta1)
   rails_12factor
   rspec-rails
   sass-rails


### PR DESCRIPTION
- Upgrade app to Rails 4.1.0.beta1.
- Removed database_cleaner gem number in Gemfile.
- Refreshed Gemfile.lock file.
